### PR TITLE
Fix bug where wrong code is compiled on tested on reqeuest. Closes #15.

### DIFF
--- a/decide-project/src/main/java/com/decide/ContinuousIntegrationServer.java
+++ b/decide-project/src/main/java/com/decide/ContinuousIntegrationServer.java
@@ -81,7 +81,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
 
             // Build project from the cloned repository
             // Specify the base directory of the Maven project
-            File baseDirectory = new File(".");
+            File baseDirectory = new File("../git/decide-project");
 
             // Create an invocation request
             InvocationRequest invocationRequest = new DefaultInvocationRequest();


### PR DESCRIPTION
When a webhook triggers, the right project code (the one in the affected branch, in /git directory) is now compiled and tested.